### PR TITLE
Add supplier CRUD screen

### DIFF
--- a/src/app/fornecedores/api/create/route.ts
+++ b/src/app/fornecedores/api/create/route.ts
@@ -7,8 +7,15 @@ export async function POST(request: Request) {
 
   try {
     const data = await request.json();
+    const { supplierInfo, ...supplierData } = data;
     const supplier = await prisma.supplier.create({
-      data,
+      data: {
+        ...supplierData,
+        supplierInfo: supplierInfo
+          ? { create: supplierInfo }
+          : undefined,
+      },
+      include: { supplierInfo: true },
     });
 
     return NextResponse.json(

--- a/src/app/fornecedores/api/get/route.ts
+++ b/src/app/fornecedores/api/get/route.ts
@@ -6,7 +6,9 @@ export async function GET() {
   await SessionAuth();
 
   try {
-    const suppliers = await prisma.supplier.findMany();
+    const suppliers = await prisma.supplier.findMany({
+      include: { supplierInfo: true, products: true },
+    });
 
     return NextResponse.json(suppliers, { status: 200 });
   } catch (error) {

--- a/src/app/fornecedores/api/update/route.ts
+++ b/src/app/fornecedores/api/update/route.ts
@@ -6,7 +6,8 @@ export async function PUT(request: Request) {
   await SessionAuth();
 
   try {
-    const { id, name, email, phone, address } = await request.json();
+    const data = await request.json();
+    const { id, supplierInfo, ...supplierData } = data;
 
     if (!id) {
       return NextResponse.json(
@@ -16,15 +17,14 @@ export async function PUT(request: Request) {
     }
 
     const updatedSupplier = await prisma.supplier.update({
-      where: {
-        id: id,
-      },
+      where: { id },
       data: {
-        name,
-        email,
-        phone,
-        address,
+        ...supplierData,
+        supplierInfo: supplierInfo
+          ? { upsert: { create: supplierInfo, update: supplierInfo } }
+          : undefined,
       },
+      include: { supplierInfo: true },
     });
 
     return NextResponse.json(

--- a/src/app/fornecedores/components/containers/SupplierModalContainer.tsx
+++ b/src/app/fornecedores/components/containers/SupplierModalContainer.tsx
@@ -1,0 +1,171 @@
+"use client";
+import { Dispatch, SetStateAction, useState, useEffect } from "react";
+import SupplierModal from "../presentations/SupplierModal";
+import { Supplier } from "@/types/Supplier";
+import { ValidityMessage } from "@/types/ValidityMessage";
+import { ValidityMessageValidation } from "@/app/lib/createValidityMessage";
+import { MessageInstance } from "antd/es/message/interface";
+import { ModalMode } from "@/types/ModalMode";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  messageApi: MessageInstance;
+  suppliersSetter: Dispatch<SetStateAction<Supplier[]>>;
+  modalMode: ModalMode;
+  selectedSupplier: Supplier | null;
+  onUpdateFinish?: () => void;
+}
+
+const initialSupplierState: Supplier = {
+  name: "",
+  cpfCnpj: "",
+  corporateName: "",
+  city: "",
+  mainContactName: "",
+  mainContactPhone: "",
+  mainContactEmail: "",
+  supplierInfo: {
+    paymentTerms: "",
+  },
+};
+
+export default function SupplierModalContainer({
+  isOpen,
+  onClose,
+  messageApi,
+  suppliersSetter,
+  modalMode,
+  selectedSupplier,
+  onUpdateFinish,
+}: Props) {
+  const [isModalLoading, setIsModalLoading] = useState(false);
+  const [supplier, setSupplier] = useState<Supplier>(initialSupplierState);
+
+  useEffect(() => {
+    if ((modalMode === ModalMode.EDIT || modalMode === ModalMode.VIEW) && selectedSupplier) {
+      setSupplier(selectedSupplier);
+    }
+  }, [modalMode, selectedSupplier]);
+
+  const handleInputChange = (field: string, value: any) => {
+    if (field === "supplierInfo") {
+      setSupplier((prev) => ({ ...prev, supplierInfo: value }));
+    } else {
+      setSupplier((prev) => ({ ...prev, [field]: value }));
+    }
+  };
+
+  const validateRequiredInputs = (value: any) => {
+    if (value === undefined || value === "" || value === null) return "error";
+    return "success";
+  };
+
+  const handleOk = () => {
+    setIsModalLoading(true);
+    modalMode === ModalMode.CREATE ? createSupplier() : updateSupplier();
+  };
+
+  const handleCancel = () => {
+    setSupplier(initialSupplierState);
+    onClose();
+  };
+
+  const createSupplier = async () => {
+    try {
+      const response = await fetch("/fornecedores/api/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(supplier),
+      });
+      if (!response.ok) {
+        const errorData: ValidityMessage = {
+          type: "error",
+          content: "Erro ao criar fornecedor.",
+          className: "mt-8",
+        };
+        ValidityMessageValidation(errorData, messageApi);
+        setIsModalLoading(false);
+        return;
+      }
+      const responseData = await response.json();
+      suppliersSetter((prev) => [...prev, responseData.supplier]);
+      const successData: ValidityMessage = {
+        type: "success",
+        content: "Fornecedor criado com sucesso.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(successData, messageApi);
+      onUpdateFinish?.();
+      onClose();
+    } catch (error) {
+      console.error("Erro ao criar fornecedor:", error);
+      const errorData: ValidityMessage = {
+        type: "error",
+        content: "Erro ao criar fornecedor.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(errorData, messageApi);
+    } finally {
+      setSupplier(initialSupplierState);
+      setIsModalLoading(false);
+    }
+  };
+
+  const updateSupplier = async () => {
+    try {
+      const response = await fetch("/fornecedores/api/update", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(supplier),
+      });
+
+      if (!response.ok) {
+        const errorData: ValidityMessage = {
+          type: "error",
+          content: "Erro ao atualizar fornecedor.",
+          className: "mt-8",
+        };
+        ValidityMessageValidation(errorData, messageApi);
+        setIsModalLoading(false);
+        return;
+      }
+      await response.json();
+      const successData: ValidityMessage = {
+        type: "success",
+        content: "Fornecedor atualizado com sucesso.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(successData, messageApi);
+      onUpdateFinish?.();
+      onClose();
+    } catch (error) {
+      console.error("Erro ao atualizar fornecedor:", error);
+      const errorData: ValidityMessage = {
+        type: "error",
+        content: "Erro ao atualizar fornecedor.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(errorData, messageApi);
+    } finally {
+      setSupplier(initialSupplierState);
+      setIsModalLoading(false);
+    }
+  };
+
+  return (
+    <SupplierModal
+      isModalOpen={isOpen}
+      isModalLoading={isModalLoading}
+      supplier={supplier}
+      handleInputChange={handleInputChange}
+      handleOk={handleOk}
+      handleCancel={handleCancel}
+      validateRequiredInputs={validateRequiredInputs}
+      modalMode={modalMode}
+      selectedSupplier={selectedSupplier}
+    />
+  );
+}

--- a/src/app/fornecedores/components/presentations/SupplierModal.tsx
+++ b/src/app/fornecedores/components/presentations/SupplierModal.tsx
@@ -1,0 +1,120 @@
+import { Modal, Form, Input, Row, Col, Button } from "antd";
+import { SupplierModalProps } from "@/types/SupplierProps";
+import { ModalMode } from "@/types/ModalMode";
+
+export default function SupplierModal({
+  isModalOpen,
+  isModalLoading,
+  supplier,
+  handleInputChange,
+  handleOk,
+  handleCancel,
+  validateRequiredInputs,
+  modalMode,
+}: SupplierModalProps) {
+  return (
+    <Modal
+      open={isModalOpen}
+      title={modalMode === ModalMode.CREATE ? "Adicionar Fornecedor" : "Fornecedor"}
+      okText={modalMode === ModalMode.CREATE ? "Criar" : "Salvar"}
+      cancelText="Cancelar"
+      confirmLoading={isModalLoading}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      width={700}
+      footer={
+        modalMode === ModalMode.VIEW
+          ? null
+          : [
+              <Button key="cancel" onClick={handleCancel}>
+                Cancelar
+              </Button>,
+              <Button key="submit" type="primary" onClick={handleOk}>
+                {modalMode === ModalMode.CREATE ? "Criar" : "Salvar"}
+              </Button>,
+            ]
+      }
+    >
+      <Form layout="vertical">
+        <Row gutter={16}>
+          <Col span={12}>
+            <Form.Item
+              label="Nome Fantasia"
+              hasFeedback
+              validateStatus={validateRequiredInputs(supplier.name)}
+              required
+            >
+              <Input
+                value={supplier.name}
+                onChange={(e) => handleInputChange("name", e.target.value)}
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+            <Form.Item label="Razão Social">
+              <Input
+                value={supplier.corporateName || ""}
+                onChange={(e) => handleInputChange("corporateName", e.target.value)}
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+            <Form.Item
+              label="CPF/CNPJ"
+              hasFeedback
+              validateStatus={validateRequiredInputs(supplier.cpfCnpj)}
+              required
+            >
+              <Input
+                value={supplier.cpfCnpj}
+                onChange={(e) => handleInputChange("cpfCnpj", e.target.value)}
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+            <Form.Item label="Cidade">
+              <Input
+                value={supplier.city || ""}
+                onChange={(e) => handleInputChange("city", e.target.value)}
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+          </Col>
+          <Col span={12}>
+            <Form.Item label="Contato Principal">
+              <Input
+                placeholder="Nome"
+                value={supplier.mainContactName || ""}
+                onChange={(e) => handleInputChange("mainContactName", e.target.value)}
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+            <Form.Item label="Telefone">
+              <Input
+                value={supplier.mainContactPhone || ""}
+                onChange={(e) => handleInputChange("mainContactPhone", e.target.value)}
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+            <Form.Item label="E-mail">
+              <Input
+                value={supplier.mainContactEmail || ""}
+                onChange={(e) => handleInputChange("mainContactEmail", e.target.value)}
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+            <Form.Item label="Condições de Pagamento">
+              <Input
+                value={supplier.supplierInfo?.paymentTerms || ""}
+                onChange={(e) =>
+                  handleInputChange("supplierInfo", {
+                    ...supplier.supplierInfo,
+                    paymentTerms: e.target.value,
+                  })
+                }
+                disabled={modalMode === ModalMode.VIEW}
+              />
+            </Form.Item>
+          </Col>
+        </Row>
+      </Form>
+    </Modal>
+  );
+}

--- a/src/app/fornecedores/page.tsx
+++ b/src/app/fornecedores/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+import { Table, Button, Tooltip, Input, Form, message, Modal } from "antd";
+import { Eye, Pencil, Trash2 } from "lucide-react";
+import { useState, useEffect, useMemo } from "react";
+import { Supplier } from "@/types/Supplier";
+import SupplierModalContainer from "./components/containers/SupplierModalContainer";
+import { ModalMode } from "@/types/ModalMode";
+import { ValidityMessage } from "@/types/ValidityMessage";
+import { ValidityMessageValidation } from "@/app/lib/createValidityMessage";
+
+const { Search } = Input;
+
+export default function Suppliers() {
+  const [suppliers, setSuppliers] = useState<Supplier[]>([]);
+  const [messageApi, contextHolder] = message.useMessage();
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [modalMode, setModalMode] = useState<ModalMode>(ModalMode.CREATE);
+  const [selectedSupplier, setSelectedSupplier] = useState<Supplier | null>(null);
+  const [refetchTrigger, setRefetchTrigger] = useState(false);
+
+  const handleDeleteSupplier = async (toDelete: Supplier) => {
+    Modal.confirm({
+      title: "Confirmar exclusão",
+      content: `Deseja excluir ${toDelete.name}?`,
+      okText: "Excluir",
+      cancelText: "Cancelar",
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          const response = await fetch(`/fornecedores/api/delete?id=${toDelete.id}`, {
+            method: "DELETE",
+          });
+          const data = await response.json();
+          if (data) {
+            const successData: ValidityMessage = {
+              type: "success",
+              content: "Fornecedor removido com sucesso.",
+              className: "mt-8",
+            };
+            ValidityMessageValidation(successData, messageApi);
+            setSuppliers((prev) => prev.filter((s) => s.id !== toDelete.id));
+          }
+        } catch (error) {
+          const errorData: ValidityMessage = {
+            type: "error",
+            content: "Erro ao remover fornecedor.",
+            className: "mt-8",
+          };
+          ValidityMessageValidation(errorData, messageApi);
+        }
+      },
+    });
+  };
+
+  const [filters, setFilters] = useState({
+    name: "",
+    cpfCnpj: "",
+    city: "",
+  });
+
+  useEffect(() => {
+    const fetchSuppliers = async () => {
+      try {
+        const res = await fetch("/fornecedores/api/get");
+        const data = await res.json();
+        setSuppliers(Array.isArray(data) ? data : data.suppliers || []);
+      } catch (error) {
+        console.error("Erro ao buscar fornecedores:", error);
+      }
+    };
+    fetchSuppliers();
+  }, [refetchTrigger]);
+
+  const filteredSuppliers = useMemo(() => {
+    return suppliers.filter((s) => {
+      const nameMatch =
+        filters.name === "" || s.name.toLowerCase().includes(filters.name.toLowerCase());
+      const cpfMatch = filters.cpfCnpj === "" || s.cpfCnpj.includes(filters.cpfCnpj);
+      const cityMatch = filters.city === "" || (s.city || "").toLowerCase().includes(filters.city.toLowerCase());
+      return nameMatch && cpfMatch && cityMatch;
+    });
+  }, [suppliers, filters]);
+
+  const columns = [
+    { title: "Nome/Razão Social", dataIndex: "name", key: "name" },
+    { title: "CPF/CNPJ", dataIndex: "cpfCnpj", key: "cpfCnpj" },
+    {
+      title: "Contato Principal",
+      key: "contact",
+      render: (_: any, record: Supplier) => (
+        <span>
+          {record.mainContactName} {record.mainContactPhone && ` - ${record.mainContactPhone}`} {record.mainContactEmail && ` - ${record.mainContactEmail}`}
+        </span>
+      ),
+    },
+    { title: "Cidade", dataIndex: "city", key: "city" },
+    {
+      title: "Ações",
+      key: "actions",
+      render: (_: any, record: Supplier) => (
+        <div className="flex justify-center gap-2">
+          <Tooltip color="#F1592A" title="Visualizar">
+            <Button
+              size="small"
+              icon={<Eye size={16} />}
+              onClick={() => {
+                setSelectedSupplier(record);
+                setModalMode(ModalMode.VIEW);
+                setIsModalOpen(true);
+              }}
+            />
+          </Tooltip>
+          <Tooltip color="#F1592A" title="Editar">
+            <Button
+              size="small"
+              icon={<Pencil size={16} />}
+              onClick={() => {
+                setSelectedSupplier(record);
+                setModalMode(ModalMode.EDIT);
+                setIsModalOpen(true);
+              }}
+            />
+          </Tooltip>
+          <Tooltip color="#F1592A" title="Excluir">
+            <Button
+              size="small"
+              icon={<Trash2 size={16} />}
+              danger
+              onClick={() => handleDeleteSupplier(record)}
+            />
+          </Tooltip>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="px-4 py-4 md:px-10 xl:px-20 space-y-8 bg-[#f9f9f9] min-h-screen">
+      {contextHolder}
+      <div className="bg-white p-4 rounded-lg shadow">
+        <Form layout="inline" className="flex flex-wrap gap-4 mb-4">
+          <Form.Item label="Nome/Razão Social">
+            <Search
+              placeholder="Buscar por nome"
+              allowClear
+              value={filters.name}
+              onChange={(e) => setFilters((f) => ({ ...f, name: e.target.value }))}
+              style={{ width: 200 }}
+            />
+          </Form.Item>
+          <Form.Item label="CPF/CNPJ">
+            <Input
+              placeholder="CPF ou CNPJ"
+              allowClear
+              value={filters.cpfCnpj}
+              onChange={(e) => setFilters((f) => ({ ...f, cpfCnpj: e.target.value }))}
+              style={{ width: 160 }}
+            />
+          </Form.Item>
+          <Form.Item label="Cidade">
+            <Input
+              placeholder="Cidade"
+              allowClear
+              value={filters.city}
+              onChange={(e) => setFilters((f) => ({ ...f, city: e.target.value }))}
+              style={{ width: 160 }}
+            />
+          </Form.Item>
+        </Form>
+        <Table
+          columns={columns}
+          bordered
+          pagination={{ position: ["bottomCenter"] }}
+          dataSource={filteredSuppliers.map((s) => ({ ...s, key: s.id }))}
+        />
+        <div className="flex justify-between items-center mt-4">
+          <div />
+          <Button
+            type="primary"
+            className="!bg-[#F1592A] hover:!bg-[#F1592A]/90"
+            onClick={() => {
+              setModalMode(ModalMode.CREATE);
+              setIsModalOpen(true);
+            }}
+          >
+            + Novo Fornecedor
+          </Button>
+        </div>
+        <SupplierModalContainer
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          messageApi={messageApi}
+          suppliersSetter={setSuppliers}
+          modalMode={modalMode}
+          selectedSupplier={selectedSupplier}
+          onUpdateFinish={() => setRefetchTrigger((prev) => !prev)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/types/Supplier.ts
+++ b/src/types/Supplier.ts
@@ -1,0 +1,28 @@
+export type SupplierInfo = {
+  paymentTerms?: string;
+  paymentMethods?: string;
+  freightTerms?: string;
+};
+
+export type Supplier = {
+  id?: number;
+  name: string;
+  corporateName?: string | null;
+  cpfCnpj: string;
+  street?: string | null;
+  number?: string | null;
+  neighborhood?: string | null;
+  city?: string | null;
+  state?: string | null;
+  zipCode?: string | null;
+  mainContactName?: string | null;
+  mainContactPhone?: string | null;
+  mainContactEmail?: string | null;
+  secondaryPhone?: string | null;
+  secondaryEmail?: string | null;
+  website?: string | null;
+  supplierInfo?: SupplierInfo | null;
+  products?: import("./Product").Product[];
+  createdAt?: string;
+  updatedAt?: string;
+};

--- a/src/types/SupplierProps.ts
+++ b/src/types/SupplierProps.ts
@@ -1,0 +1,13 @@
+import { Supplier, SupplierInfo } from "./Supplier";
+
+export type SupplierModalProps = {
+  isModalOpen: boolean;
+  isModalLoading: boolean;
+  supplier: Supplier;
+  handleInputChange: (field: string, value: any) => void;
+  handleOk: () => void;
+  handleCancel: () => void;
+  validateRequiredInputs: (value: any) => "success" | "error" | "validating";
+  modalMode: import("./ModalMode").ModalMode;
+  selectedSupplier: Supplier | null;
+};


### PR DESCRIPTION
## Summary
- create supplier type definitions
- implement SupplierModal UI and container logic
- build fornecedores page with CRUD functionality
- extend supplier API routes to handle supplierInfo and returns

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c5e360108326aaa58d9c59852b27