### PR TITLE
Integrate dashboard with database

### DIFF
--- a/src/app/dashboard/api/data/route.ts
+++ b/src/app/dashboard/api/data/route.ts
@@ -1,0 +1,100 @@
+import { prisma } from "@/app/lib/prisma";
+import { NextResponse } from "next/server";
+import { subDays, startOfDay, format } from "date-fns";
+
+export async function GET() {
+  try {
+    const products = await prisma.product.findMany({ include: { Category: true } });
+    const totalStock = products.reduce((acc, p) => acc + p.quantity, 0);
+    const totalStockValue = products.reduce(
+      (acc, p) => acc + p.sellingPrice * p.quantity,
+      0
+    );
+    const criticalStock = await prisma.product.count({ where: { quantity: { lt: 5 } } });
+
+    const startDate = startOfDay(subDays(new Date(), 6));
+    const movements = await prisma.stockMovement.findMany({
+      where: { date: { gte: startDate } },
+      include: { Product: true },
+    });
+
+    const recentMovements = movements
+      .sort((a, b) => b.date.getTime() - a.date.getTime())
+      .slice(0, 5)
+      .map((m) => ({
+        product: m.Product.name,
+        type: m.type === "in" ? "Entrada" : "Saída",
+        quantity: m.quantity,
+        date: format(m.date, "yyyy-MM-dd HH:mm"),
+      }));
+
+    const weekDays: string[] = [];
+    for (let i = 6; i >= 0; i--) {
+      weekDays.push(format(subDays(new Date(), i), "EEE"));
+    }
+
+    const weeklyMap: Record<string, { entradas: number; saidas: number }> = {};
+    weekDays.forEach((day) => {
+      weeklyMap[day] = { entradas: 0, saidas: 0 };
+    });
+
+    movements.forEach((m) => {
+      const key = format(m.date, "EEE");
+      if (m.type === "in") weeklyMap[key].entradas += m.quantity;
+      else weeklyMap[key].saidas += m.quantity;
+    });
+
+    const weeklyData = weekDays.map((day) => ({
+      day,
+      ...weeklyMap[day],
+    }));
+
+    const productMovMap: Record<string, number> = {};
+    movements.forEach((m) => {
+      const name = m.Product.name;
+      productMovMap[name] = (productMovMap[name] || 0) + m.quantity;
+    });
+    const topProducts = Object.entries(productMovMap)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 4)
+      .map(([name, movimentado]) => ({ name, movimentado }));
+
+    const categoryMap: Record<string, number> = {};
+    products.forEach((p) => {
+      const title = p.Category?.title || "Sem Categoria";
+      categoryMap[title] = (categoryMap[title] || 0) + p.quantity;
+    });
+    const categoriasEstoque = Object.entries(categoryMap).map(([categoria, valor]) => ({
+      categoria,
+      valor,
+    }));
+
+    const estoqueHistorico: { day: string; estoque: number }[] = [];
+    let stock = totalStock;
+    for (let i = weekDays.length - 1; i >= 0; i--) {
+      const day = weekDays[i];
+      estoqueHistorico.unshift({ day, estoque: stock });
+      stock -= weeklyMap[day].entradas - weeklyMap[day].saidas;
+    }
+
+    return NextResponse.json({
+      totalStock,
+      recentEntries: weeklyData.reduce((s, d) => s + d.entradas, 0),
+      recentExits: weeklyData.reduce((s, d) => s + d.saidas, 0),
+      criticalStock,
+      totalStockValue,
+      weeklyData,
+      evolucaoMovimentacoes: weeklyData,
+      topProducts,
+      categoriasEstoque,
+      recentMovements,
+      estoqueHistorico,
+    });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { message: "Erro ao obter dados do dashboard." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -25,71 +25,25 @@ import {
 } from "recharts";
 
 import DashboardCard from "@/app/components/DashboardCard";
+import { useDashboardData } from "@/app/hooks/dashboard/useDashboardData";
 
 export default function Dashboard() {
-  const recentMovements = [
-    {
-      product: "Teclado USB",
-      type: "Entrada",
-      quantity: 10,
-      date: "2025-05-18 09:21",
-    },
-    {
-      product: 'Monitor 24"',
-      type: "Saída",
-      quantity: 2,
-      date: "2025-05-18 08:45",
-    },
-    {
-      product: "Mouse Gamer",
-      type: "Entrada",
-      quantity: 15,
-      date: "2025-05-17 14:10",
-    },
-  ];
+  const { data } = useDashboardData();
 
-  const weeklyData = [
-    { day: "Seg", entradas: 40, saidas: 24 },
-    { day: "Ter", entradas: 30, saidas: 18 },
-    { day: "Qua", entradas: 20, saidas: 32 },
-    { day: "Qui", entradas: 27, saidas: 20 },
-    { day: "Sex", entradas: 35, saidas: 22 },
-    { day: "Sáb", entradas: 45, saidas: 28 },
-    { day: "Dom", entradas: 25, saidas: 15 },
-  ];
+  const recentMovements = data?.recentMovements ?? [];
+  const weeklyData = data?.weeklyData ?? [];
 
-  const evolucaoMovimentacoes = [
-    { day: "Seg", entradas: 40, saidas: 24 },
-    { day: "Ter", entradas: 30, saidas: 18 },
-    { day: "Qua", entradas: 20, saidas: 32 },
-    { day: "Qui", entradas: 27, saidas: 20 },
-    { day: "Sex", entradas: 35, saidas: 22 },
-    { day: "Sáb", entradas: 45, saidas: 28 },
-    { day: "Dom", entradas: 25, saidas: 15 },
-  ];
 
-  const topProducts = [
-    { name: "Teclado USB", movimentado: 50 },
-    { name: 'Monitor 24"', movimentado: 38 },
-    { name: "Mouse Gamer", movimentado: 60 },
-    { name: "HD Externo", movimentado: 22 },
-  ];
+  const estoqueHistorico = data?.estoqueHistorico ?? [];
+  const categoriasEstoque = data?.categoriasEstoque ?? [];
+  const evolucaoMovimentacoes = data?.evolucaoMovimentacoes ?? [];
+  const topProducts = data?.topProducts ?? [];
 
-  const estoqueHistorico = [
-    { day: "Seg", estoque: 1100 },
-    { day: "Ter", estoque: 1120 },
-    { day: "Qua", estoque: 1070 },
-    { day: "Qui", estoque: 1150 },
-    { day: "Sex", estoque: 1200 },
-    { day: "Sáb", estoque: 1250 },
-    { day: "Dom", estoque: 1230 },
-  ];
-
-  const categoriasEstoque = [
-    { categoria: "Periféricos", valor: 800 },
-    { categoria: "Monitores", valor: 400 },
-    { categoria: "Acessórios", valor: 363 },
-  ];
+  const totalStock = data?.totalStock ?? 0;
+  const recentEntries = data?.recentEntries ?? 0;
+  const recentExits = data?.recentExits ?? 0;
+  const criticalStock = data?.criticalStock ?? 0;
+  const totalStockValue = data?.totalStockValue ?? 0;
 
   const COLORS = ["#F1592A", "#2196F3", "#FFC107"];
 
@@ -100,35 +54,38 @@ export default function Dashboard() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6 mb-8">
           <DashboardCard
             title="Estoque Total"
-            value="1.563"
+            value={totalStock.toString()}
             color="#F1592A"
             resize={false}
             icon={<PackageCheck size={28} />}
           />
           <DashboardCard
             title="Entradas Recentes"
-            value="+240"
+            value={`+${recentEntries}`}
             color="#4CAF50"
             resize={false}
             icon={<ArrowDown size={28} />}
           />
           <DashboardCard
             title="Saídas Recentes"
-            value="-120"
+            value={`-${recentExits}`}
             color="#F44336"
             resize={false}
             icon={<ArrowUp size={28} />}
           />
           <DashboardCard
             title="Estoque Crítico"
-            value="5"
+            value={criticalStock.toString()}
             color="#FFC107"
             resize={false}
             icon={<AlertTriangle size={28} />}
           />
           <DashboardCard
             title="Valor Total em Estoque"
-            value="R$ 18.320,00"
+            value={totalStockValue.toLocaleString("pt-BR", {
+              style: "currency",
+              currency: "BRL",
+            })}
             color="#2196F3"
             resize={true}
             icon={<Warehouse size={28} />}
@@ -171,8 +128,14 @@ export default function Dashboard() {
           <h2 className="text-lg font-bold text-[#1F1F1F] mb-2">
             Produto em Destaque
           </h2>
-          <p className="text-2xl font-bold text-[#F1592A] mb-1">Mouse Gamer</p>
-          <span className="text-[#666666]">Movimentado 60x na semana</span>
+          <p className="text-2xl font-bold text-[#F1592A] mb-1">
+            {topProducts[0]?.name ?? "-"}
+          </p>
+          {topProducts[0] && (
+            <span className="text-[#666666]">
+              Movimentado {topProducts[0].movimentado}x na semana
+            </span>
+          )}
         </div>
 
         {/* Pie Chart: Distribuição por Categoria */}

--- a/src/app/hooks/dashboard/useDashboardData.tsx
+++ b/src/app/hooks/dashboard/useDashboardData.tsx
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { DashboardData } from "@/types/Dashboard";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export const useDashboardData = () => {
+  const { data, error, isLoading } = useSWR<DashboardData>(
+    "/dashboard/api/data",
+    fetcher
+  );
+
+  return { data, error, isLoading };
+};

--- a/src/types/Dashboard.ts
+++ b/src/types/Dashboard.ts
@@ -1,0 +1,41 @@
+export type DashboardMovement = {
+  product: string;
+  type: string;
+  quantity: number;
+  date: string;
+};
+
+export type DashboardWeekly = {
+  day: string;
+  entradas: number;
+  saidas: number;
+};
+
+export type DashboardCategory = {
+  categoria: string;
+  valor: number;
+};
+
+export type DashboardTopProduct = {
+  name: string;
+  movimentado: number;
+};
+
+export type DashboardStock = {
+  day: string;
+  estoque: number;
+};
+
+export type DashboardData = {
+  totalStock: number;
+  recentEntries: number;
+  recentExits: number;
+  criticalStock: number;
+  totalStockValue: number;
+  weeklyData: DashboardWeekly[];
+  evolucaoMovimentacoes: DashboardWeekly[];
+  topProducts: DashboardTopProduct[];
+  categoriasEstoque: DashboardCategory[];
+  recentMovements: DashboardMovement[];
+  estoqueHistorico: DashboardStock[];
+};


### PR DESCRIPTION
## Summary
- create API route to aggregate dashboard data from Prisma
- add SWR hook to fetch dashboard data
- define dashboard data types
- pull real data in Dashboard page instead of mock data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685219af465c8326af3b13c9ba44c96b