### PR TITLE
Implement stock movement management page

### DIFF
--- a/src/app/hooks/stockMovements/useStockMovements.tsx
+++ b/src/app/hooks/stockMovements/useStockMovements.tsx
@@ -1,0 +1,11 @@
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export const useStockMovements = () => {
+  const { data, error, isLoading, mutate } = useSWR(
+    "/estoque/api/get",
+    fetcher
+  );
+  return { stockMovements: data, error, isLoadingMovements: isLoading, mutate };
+};

--- a/src/app/movimentacoes/components/containers/StockMovementModalContainer.tsx
+++ b/src/app/movimentacoes/components/containers/StockMovementModalContainer.tsx
@@ -1,0 +1,162 @@
+"use client";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { StockMovement } from "@/types/StockMovement";
+import StockMovementModal from "../presentations/StockMovementModal";
+import { ValidityMessage } from "@/types/ValidityMessage";
+import { ValidityMessageValidation } from "@/app/lib/createValidityMessage";
+import { MessageInstance } from "antd/es/message/interface";
+import { ModalMode } from "@/types/ModalMode";
+import { useProducts } from "@/app/hooks/products/useProducts";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  messageApi: MessageInstance;
+  movementsSetter: Dispatch<SetStateAction<StockMovement[]>>;
+  modalMode: ModalMode;
+  selectedMovement: StockMovement | null;
+  onUpdateFinish?: () => void;
+}
+
+const initialMovement: StockMovement = {
+  productId: 0,
+  type: "in",
+  quantity: 1,
+};
+
+export default function StockMovementModalContainer({
+  isOpen,
+  onClose,
+  messageApi,
+  movementsSetter,
+  modalMode,
+  selectedMovement,
+  onUpdateFinish,
+}: Props) {
+  const [isModalLoading, setIsModalLoading] = useState(false);
+  const [movement, setMovement] = useState<StockMovement>(initialMovement);
+
+  const { data: products = [], isLoading: isLoadingProducts } = useProducts();
+
+  useEffect(() => {
+    if ((modalMode === ModalMode.EDIT || modalMode === ModalMode.VIEW) && selectedMovement) {
+      setMovement(selectedMovement);
+    }
+  }, [modalMode, selectedMovement]);
+
+  const handleInputChange = (field: string, value: any) => {
+    setMovement((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const validateRequiredInputs = (value: any) => {
+    if (value === undefined || value === "" || value === null) return "error";
+    return "success";
+  };
+
+  const handleOk = () => {
+    setIsModalLoading(true);
+    modalMode === ModalMode.CREATE ? createMovement() : updateMovement();
+  };
+
+  const handleCancel = () => {
+    setMovement(initialMovement);
+    onClose();
+  };
+
+  const createMovement = async () => {
+    try {
+      const response = await fetch("/estoque/api/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(movement),
+      });
+      if (!response.ok) {
+        const errorData: ValidityMessage = {
+          type: "error",
+          content: "Erro ao criar movimentação.",
+          className: "mt-8",
+        };
+        ValidityMessageValidation(errorData, messageApi);
+        setIsModalLoading(false);
+        return;
+      }
+      const data = await response.json();
+      movementsSetter((prev) => [...prev, data]);
+      const successData: ValidityMessage = {
+        type: "success",
+        content: "Movimentação registrada com sucesso.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(successData, messageApi);
+      onUpdateFinish?.();
+      onClose();
+    } catch (error) {
+      console.error("Erro ao criar movimentação:", error);
+      const errorData: ValidityMessage = {
+        type: "error",
+        content: "Erro ao criar movimentação.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(errorData, messageApi);
+    } finally {
+      setMovement(initialMovement);
+      setIsModalLoading(false);
+    }
+  };
+
+  const updateMovement = async () => {
+    try {
+      const response = await fetch("/estoque/api/update", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(movement),
+      });
+      if (!response.ok) {
+        const errorData: ValidityMessage = {
+          type: "error",
+          content: "Erro ao atualizar movimentação.",
+          className: "mt-8",
+        };
+        ValidityMessageValidation(errorData, messageApi);
+        setIsModalLoading(false);
+        return;
+      }
+      const data = await response.json();
+      const successData: ValidityMessage = {
+        type: "success",
+        content: "Movimentação atualizada com sucesso.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(successData, messageApi);
+      onUpdateFinish?.();
+      onClose();
+    } catch (error) {
+      console.error("Erro ao atualizar movimentação:", error);
+      const errorData: ValidityMessage = {
+        type: "error",
+        content: "Erro ao atualizar movimentação.",
+        className: "mt-8",
+      };
+      ValidityMessageValidation(errorData, messageApi);
+    } finally {
+      setMovement(initialMovement);
+      setIsModalLoading(false);
+    }
+  };
+
+  return (
+    <StockMovementModal
+      isModalOpen={isOpen}
+      isModalLoading={isModalLoading}
+      movement={movement}
+      products={products}
+      isLoadingProducts={isLoadingProducts}
+      handleInputChange={handleInputChange}
+      handleOk={handleOk}
+      handleCancel={handleCancel}
+      validateRequiredInputs={validateRequiredInputs}
+      modalMode={modalMode}
+      selectedMovement={selectedMovement}
+    />
+  );
+}

--- a/src/app/movimentacoes/components/presentations/StockMovementModal.tsx
+++ b/src/app/movimentacoes/components/presentations/StockMovementModal.tsx
@@ -1,0 +1,83 @@
+import { Modal, Form, Select, InputNumber, Button } from "antd";
+import { StockMovementModalProps } from "@/types/StockMovementProps";
+import { ModalMode } from "@/types/ModalMode";
+
+export default function StockMovementModal({
+  isModalOpen,
+  isModalLoading,
+  movement,
+  products,
+  isLoadingProducts,
+  handleInputChange,
+  handleOk,
+  handleCancel,
+  validateRequiredInputs,
+  modalMode,
+}: StockMovementModalProps) {
+  return (
+    <Modal
+      open={isModalOpen}
+      title={modalMode === ModalMode.CREATE ? "Registrar Movimentação" : "Movimentação"}
+      okText={modalMode === ModalMode.CREATE ? "Criar" : "Salvar"}
+      cancelText="Cancelar"
+      confirmLoading={isModalLoading}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      width={500}
+      footer={
+        modalMode === ModalMode.VIEW
+          ? null
+          : [
+              <Button key="cancel" onClick={handleCancel}>
+                Cancelar
+              </Button>,
+              <Button key="submit" type="primary" onClick={handleOk}>
+                {modalMode === ModalMode.CREATE ? "Criar" : "Salvar"}
+              </Button>,
+            ]
+      }
+    >
+      <Form layout="vertical">
+        <Form.Item
+          label="Produto"
+          hasFeedback
+          validateStatus={validateRequiredInputs(movement.productId)}
+          required
+        >
+          <Select
+            placeholder="Selecione um produto"
+            value={movement.productId || undefined}
+            onChange={(value) => handleInputChange("productId", value)}
+            loading={isLoadingProducts}
+            options={(products ?? []).map((p) => ({ label: p.name, value: p.id }))}
+            disabled={modalMode === ModalMode.VIEW}
+          />
+        </Form.Item>
+        <Form.Item label="Tipo" required>
+          <Select
+            value={movement.type}
+            onChange={(value) => handleInputChange("type", value)}
+            disabled={modalMode === ModalMode.VIEW}
+            options={[
+              { label: "Entrada", value: "in" },
+              { label: "Saída", value: "out" },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item
+          label="Quantidade"
+          hasFeedback
+          validateStatus={validateRequiredInputs(movement.quantity)}
+          required
+        >
+          <InputNumber
+            min={1}
+            value={movement.quantity}
+            onChange={(value) => handleInputChange("quantity", value)}
+            disabled={modalMode === ModalMode.VIEW}
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/src/app/movimentacoes/page.tsx
+++ b/src/app/movimentacoes/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+import { Table, Button, Tag, Tooltip, message, Modal } from "antd";
+import { useState, useEffect } from "react";
+import { StockMovement } from "@/types/StockMovement";
+import { Eye, Pencil, Trash2 } from "lucide-react";
+import StockMovementModalContainer from "./components/containers/StockMovementModalContainer";
+import { ModalMode } from "@/types/ModalMode";
+import { ValidityMessage } from "@/types/ValidityMessage";
+import { ValidityMessageValidation } from "@/app/lib/createValidityMessage";
+
+export default function Movements() {
+  const [movements, setMovements] = useState<StockMovement[]>([]);
+  const [messageApi, contextHolder] = message.useMessage();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<ModalMode>(ModalMode.CREATE);
+  const [selectedMovement, setSelectedMovement] = useState<StockMovement | null>(null);
+  const [refetchTrigger, setRefetchTrigger] = useState(false);
+
+  useEffect(() => {
+    const fetchMovements = async () => {
+      try {
+        const res = await fetch("/estoque/api/get");
+        const data = await res.json();
+        setMovements(Array.isArray(data) ? data : data.movements || []);
+      } catch (error) {
+        console.error("Erro ao buscar movimentações:", error);
+      }
+    };
+    fetchMovements();
+  }, [refetchTrigger]);
+
+  const handleDeleteMovement = async (movement: StockMovement) => {
+    Modal.confirm({
+      title: "Confirmar exclusão",
+      content: `Deseja excluir esta movimentação?`,
+      okText: "Excluir",
+      cancelText: "Cancelar",
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          const response = await fetch(`/estoque/api/delete?id=${movement.id}`, {
+            method: "DELETE",
+          });
+          if (response.ok) {
+            const successData: ValidityMessage = {
+              type: "success",
+              content: "Movimentação removida com sucesso.",
+              className: "mt-8",
+            };
+            ValidityMessageValidation(successData, messageApi);
+            setMovements((prev) => prev.filter((m) => m.id !== movement.id));
+          }
+        } catch (error) {
+          const errorData: ValidityMessage = {
+            type: "error",
+            content: "Erro ao remover movimentação.",
+            className: "mt-8",
+          };
+          ValidityMessageValidation(errorData, messageApi);
+        }
+      },
+    });
+  };
+
+  const columns = [
+    { title: "Produto", dataIndex: ["Product", "name"], key: "product" },
+    {
+      title: "Tipo",
+      dataIndex: "type",
+      key: "type",
+      render: (value: string) => (
+        <Tag color={value === "in" ? "green" : "red"}>
+          {value === "in" ? "Entrada" : "Saída"}
+        </Tag>
+      ),
+    },
+    { title: "Quantidade", dataIndex: "quantity", key: "quantity" },
+    {
+      title: "Data",
+      dataIndex: "date",
+      key: "date",
+      render: (value: string) => new Date(value).toLocaleString(),
+    },
+    {
+      title: "Ações",
+      key: "actions",
+      render: (_: any, record: StockMovement) => (
+        <div className="flex justify-center gap-2">
+          <Tooltip color="#F1592A" title="Visualizar">
+            <Button
+              size="small"
+              icon={<Eye size={16} />}
+              onClick={() => {
+                setSelectedMovement(record);
+                setModalMode(ModalMode.VIEW);
+                setIsModalOpen(true);
+              }}
+            />
+          </Tooltip>
+          <Tooltip color="#F1592A" title="Editar">
+            <Button
+              size="small"
+              icon={<Pencil size={16} />}
+              onClick={() => {
+                setSelectedMovement(record);
+                setModalMode(ModalMode.EDIT);
+                setIsModalOpen(true);
+              }}
+            />
+          </Tooltip>
+          <Tooltip color="#F1592A" title="Excluir">
+            <Button
+              size="small"
+              icon={<Trash2 size={16} />}
+              danger
+              onClick={() => handleDeleteMovement(record)}
+            />
+          </Tooltip>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="px-4 py-4 md:px-10 xl:px-20 space-y-8 bg-[#f9f9f9] min-h-screen">
+      {contextHolder}
+      <Table
+        columns={columns}
+        bordered
+        pagination={{ position: ["bottomCenter"] }}
+        dataSource={movements.map((m) => ({ ...m, key: m.id }))}
+      />
+      <div className="flex justify-between items-center mt-4">
+        <div />
+        <Button
+          type="primary"
+          className="!bg-[#F1592A] hover:!bg-[#F1592A]/90"
+          onClick={() => {
+            setModalMode(ModalMode.CREATE);
+            setIsModalOpen(true);
+          }}
+        >
+          + Nova Movimentação
+        </Button>
+      </div>
+      <StockMovementModalContainer
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        messageApi={messageApi}
+        movementsSetter={setMovements}
+        modalMode={modalMode}
+        selectedMovement={selectedMovement}
+        onUpdateFinish={() => setRefetchTrigger((prev) => !prev)}
+      />
+    </div>
+  );
+}

--- a/src/types/StockMovement.ts
+++ b/src/types/StockMovement.ts
@@ -1,0 +1,8 @@
+export type StockMovement = {
+  id?: number;
+  productId: number;
+  type: "in" | "out";
+  quantity: number;
+  date?: string;
+  Product?: { name: string };
+};

--- a/src/types/StockMovementProps.ts
+++ b/src/types/StockMovementProps.ts
@@ -1,0 +1,16 @@
+import { Product } from "./Product";
+import { StockMovement } from "./StockMovement";
+
+export type StockMovementModalProps = {
+  isModalOpen: boolean;
+  isModalLoading: boolean;
+  movement: StockMovement;
+  products: Product[];
+  isLoadingProducts: boolean;
+  handleInputChange: (field: string, value: any) => void;
+  handleOk: () => void;
+  handleCancel: () => void;
+  validateRequiredInputs: (value: any) => "success" | "error" | "validating";
+  modalMode: import("./ModalMode").ModalMode;
+  selectedMovement: StockMovement | null;
+};


### PR DESCRIPTION
## Summary
- add StockMovement types
- provide StockMovement modal and container components
- create page for stock movements
- add SWR hook for stock movements data

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521f1c35088326a6ecdf4c03048aaa