### PR TITLE
Fix request body handling in stock movement create API

### DIFF
--- a/src/app/estoque/api/create/route.ts
+++ b/src/app/estoque/api/create/route.ts
@@ -5,7 +5,9 @@ import SessionAuth from "@/app/lib/sessionAuth";
 export async function POST(request: Request) {
   await SessionAuth();
   try {
-    const { productId, type, quantity } = await request.json();
+    // Parse request body only once to avoid "Body has already been read" errors
+    const data = await request.json();
+    const { productId, type, quantity } = data;
 
     if (!productId || !type || !quantity) {
       return NextResponse.json(
@@ -14,7 +16,6 @@ export async function POST(request: Request) {
       );
     }
 
-    const data = request.json();
     const movement = await StockMovementService.create(data);
 
     return NextResponse.json(movement, { status: 201 });


### PR DESCRIPTION
## Summary
- read request body once in the stock movement create route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535bb9496c8326a60833ff49befde8