### PR TITLE
Check invalid login credentials

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -21,7 +21,9 @@ export default function Login() {
         password,
       });
 
-      if (!result?.error) {
+      if (result?.error) {
+        toast.error("Usuário ou senha incorretos.");
+      } else {
         window.location.href = result?.url || "/";
         toast.success("Login realizado com sucesso!");
       }


### PR DESCRIPTION
## Summary
- show a toast message when the login credentials do not exist

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_685cb41478888326ad020fc7dd4ba436