### PR TITLE
Add admin permissions panel

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,7 +91,7 @@ model User {
   name      String
   email     String   @unique
   password  String
-  role      String   @default("user")
+  role      Int      @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -33,7 +33,7 @@ export const authOptions: AuthOptions = {
           id: user.id.toString(),
           name: user.name,
           email: user.email,
-          role: user.role,
+          role: Number(user.role),
         };
       },
     }),
@@ -47,7 +47,7 @@ export const authOptions: AuthOptions = {
       return token;
     },
     async session({ session, token }) {
-      if (token?.role) session.user.role = token.role as string;
+      if (token?.role !== undefined) session.user.role = token.role as number;
       return session;
     },
   },

--- a/src/app/layouts/SideBar.tsx
+++ b/src/app/layouts/SideBar.tsx
@@ -10,6 +10,7 @@ import {
   LogOut,
   Boxes,
   TruckElectric,
+  ShieldCheck,
 } from "lucide-react";
 import { useSession, signOut } from "next-auth/react";
 import { usePathname } from "next/navigation";
@@ -78,6 +79,15 @@ export default function SideBar({ open, onClose }: SideBarProps) {
             <TruckElectric className="w-5 h-5" />
             {open && <span>Fornecedores</span>}
           </Link>
+          {user?.role === 1 && (
+            <Link
+              href="/permissoes"
+              className={`flex items-center gap-3 py-2 px-3 rounded-lg text-[#666] hover:bg-[#F1592A]/10 hover:text-[#F1592A] transition-all cursor-pointer ease-in hover:translate-x-[0.1rem] ${!open ? "justify-center" : ""} ${pathname.startsWith("/permissoes") ? "bg-[#F1592A]/10 text-[#F1592A] font-semibold" : ""}`}
+            >
+              <ShieldCheck className="w-5 h-5" />
+              {open && <span>Permissões</span>}
+            </Link>
+          )}
         </nav>
       </div>
 

--- a/src/app/permissoes/PermissionsPanel.tsx
+++ b/src/app/permissoes/PermissionsPanel.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { useState } from "react";
+import { UserRole } from "@/types/UserRole";
+
+const modules = ["Produtos", "Movimentações", "Categorias", "Fornecedores"];
+
+const roles = [
+  { id: UserRole.OPERADOR, name: "Operador" },
+  { id: UserRole.GERENTE, name: "Gerente" },
+  { id: UserRole.ADMIN, name: "Administrador" },
+];
+
+type PermissionsState = Record<number, Record<string, boolean>>;
+
+export default function PermissionsPanel() {
+  const [permissions, setPermissions] = useState<PermissionsState>(() => {
+    const initial: PermissionsState = {};
+    roles.forEach((r) => {
+      initial[r.id] = {} as Record<string, boolean>;
+      modules.forEach((m) => {
+        initial[r.id][m] = r.id === UserRole.ADMIN;
+      });
+    });
+    return initial;
+  });
+
+  const toggle = (roleId: number, module: string) => {
+    setPermissions((prev) => ({
+      ...prev,
+      [roleId]: { ...prev[roleId], [module]: !prev[roleId][module] },
+    }));
+  };
+
+  return (
+    <div className="p-6 bg-white border border-[#E0E0E0] rounded-2xl shadow-md">
+      <h2 className="text-lg font-bold mb-4">Controle Avançado de Permissões</h2>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Módulo</th>
+            {roles.map((role) => (
+              <th key={role.id} className="p-2 text-center">
+                {role.name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {modules.map((module) => (
+            <tr key={module} className="border-t">
+              <td className="p-2 font-medium">{module}</td>
+              {roles.map((role) => (
+                <td key={role.id} className="p-2 text-center">
+                  <input
+                    type="checkbox"
+                    checked={permissions[role.id][module]}
+                    onChange={() => toggle(role.id, module)}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/permissoes/page.tsx
+++ b/src/app/permissoes/page.tsx
@@ -1,0 +1,16 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import PermissionsPanel from "./PermissionsPanel";
+
+export default async function PermissoesPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 1) {
+    redirect("/");
+  }
+  return (
+    <main className="py-4 px-4 md:px-10 xl:px-20">
+      <PermissionsPanel />
+    </main>
+  );
+}

--- a/src/types/UserRole.ts
+++ b/src/types/UserRole.ts
@@ -1,0 +1,5 @@
+export enum UserRole {
+  OPERADOR = 0,
+  ADMIN = 1,
+  GERENTE = 2,
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -6,15 +6,15 @@ declare module "next-auth" {
       name?: string | null;
       email?: string | null;
       image?: string | null;
-      role?: string | null;
+      role?: number | null;
     };
   }
 
   interface User {
-    role?: string | null;
+    role?: number | null;
   }
 
   interface JWT {
-    role?: string | null;
+    role?: number | null;
   }
 }


### PR DESCRIPTION
## Summary
- make user role a numeric field in Prisma schema
- support numeric roles in NextAuth session callbacks
- show Permissions link on sidebar for admins only
- add basic permissions panel page restricted to admin
- define role enum for front-end and update NextAuth types

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619c3366808326ad240085659ee065