### PR TITLE
Add 403 screen and enable middleware

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  matcher: ["/produtos/api/:path*", "/estoque/api/:path*"],
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: '403 - Acesso Negado',
+};
+
+export default function ForbiddenPage() {
+  return (
+    <main className="flex flex-col items-center justify-center h-screen bg-background text-foreground animate-slide-in-item">
+      <h1 className="text-6xl font-bold text-primary mb-4">403</h1>
+      <p className="text-xl mb-6">Você não tem acesso a esta página.</p>
+      <Link href="/login" className="text-info hover:underline">
+        Voltar para o login
+      </Link>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import Dashboard from "./dashboard/page";
 export default async function Home() {
   const session = await getServerSession(authOptions);
   if (!session) {
-    redirect("/login");
+    redirect("/403");
   }
   return <Dashboard />;
 }

--- a/src/app/permissoes/page.tsx
+++ b/src/app/permissoes/page.tsx
@@ -7,7 +7,7 @@ import { UserRole } from "@/types/UserRole";
 export default async function PermissoesPage() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== UserRole.ADMIN) {
-    redirect("/");
+    redirect("/403");
   }
   return (
     <main className="py-4 px-4 md:px-10 xl:px-20">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,6 @@ export async function middleware(req: NextRequest) {
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
 
   const protectedRoutes = ["/produtos/api", "/estoque/api"];
-
   const isProtected = protectedRoutes.some((path) =>
     req.nextUrl.pathname.startsWith(path)
   );
@@ -17,3 +16,7 @@ export async function middleware(req: NextRequest) {
 
   return NextResponse.next();
 }
+
+export const config = {
+  matcher: ["/produtos/api/:path*", "/estoque/api/:path*"]
+};


### PR DESCRIPTION
## Summary
- implement `src/app/403/page.tsx` with white/orange/blue colours and animation
- redirect unauthenticated or unauthorized users to the new 403 page
- move middleware to `src/middleware.ts` and export matcher config
- clean up next.config.ts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f19a95f80832685fac88b924b33aa