### PR TITLE
Implement global auth redirect and clean 403 layout

### DIFF
--- a/src/app/layouts/ClientLayout.tsx
+++ b/src/app/layouts/ClientLayout.tsx
@@ -14,12 +14,13 @@ export default function ClientLayout({
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const pathname = usePathname();
   const isLoginPage = pathname === "/login";
+  const isForbiddenPage = pathname === "/403";
   useEffect(() => {}, []);
 
   return (
     <div className="flex min-h-screen bg-background dark:bg-background-dark">
       <SessionProvider>
-        {!isLoginPage && (
+        {!isLoginPage && !isForbiddenPage && (
           <SideBar
             open={isSidebarOpen}
             onClose={() => setIsSidebarOpen(false)}
@@ -27,11 +28,13 @@ export default function ClientLayout({
         )}
         <div
           className={`flex-1 min-w-0 transition-all duration-300 ${
-            !isLoginPage && isSidebarOpen ? "ml-52" : "ml-0"
+            !isLoginPage && !isForbiddenPage && isSidebarOpen ? "ml-52" : "ml-0"
           }`}
         >
           {!isLoginPage && (
-            <Header onMenuClick={() => setIsSidebarOpen((v) => !v)} />
+            <Header
+              onMenuClick={() => setIsSidebarOpen((v) => !v)}
+            />
           )}
           <main>{children}</main>
         </div>

--- a/src/app/layouts/Header.tsx
+++ b/src/app/layouts/Header.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import Image from "next/image";
 import { Bell, Search, Sun, PanelLeft, Moon } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useDarkMode } from "../hooks/useDarkMode";
@@ -9,46 +9,53 @@ type HeaderProps = {
 };
 
 export default function Header({ onMenuClick }: HeaderProps) {
+  const routerPath = usePathname();
   const pathname =
-    usePathname().replace("/", "").charAt(0).toUpperCase() +
-    usePathname().slice(2);
+    routerPath.replace("/", "").charAt(0).toUpperCase() + routerPath.slice(2);
+  const isForbiddenPage = routerPath === "/403";
   const { isDarkMode, toggleDarkMode } = useDarkMode();
 
   return (
     <header className="w-full pl-22 h-16 bg-card dark:bg-card-dark border-b border-border dark:border-border-dark flex items-center justify-between px-6 shadow-sm z-10 sticky top-0">
-      {/* Search bar */}
-      <div className="flex justify-start items-center gap-8 text-sm text-foregroundSec dark:text-foregroundSec-dark">
-        <button onClick={onMenuClick}>
-          <PanelLeft className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
-        </button>
-        <span className="text-lg font-semibold text-center text-foregroundSec dark:text-foregroundSec-dark hover:bg-border dark:hover:bg-border-dark px-4 py-2 rounded-2xl transition-all hover:translate-x-0.5 ease-linear">
-          {pathname}
-        </span>
-      </div>
-      <div className="flex items-center gap-8 w-85">
-        <div className="flex items-center bg-muted/20 dark:bg-muted/40 px-3 py-1.5 rounded-full w-full text-muted dark:text-muted-dark hover:bg-muted/30 dark:hover:bg-muted-dark/30 cursor-pointer">
-          <Search className="w-4 h-4 mr-2 transition-transform ease-in hover:-translate-y-[0.1rem]" />
-          <input
-            type="text"
-            placeholder="Search"
-            className="bg-transparent w-full outline-none text-sm placeholder-muted dark:placeholder-muted-dark text-foreground dark:text-foreground-dark cursor-pointer transition-transform ease-in hover:-translate-y-[0.1rem]"
-          />
-          <kbd className="ml-2 text-xs text-muted dark:text-muted-dark bg-muted/20 dark:bg-muted-dark/20 px-1.5 py-0.5 rounded">
-            /
-          </kbd>
+      {isForbiddenPage ? (
+        <div className="flex justify-center items-center w-full">
+          <Image src="/logo-stock-pro.png" alt="Logo" width={120} height={40} />
         </div>
-        <button>
-          <Bell className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
-        </button>
-        <button onClick={toggleDarkMode}>
-          {isDarkMode ? (
-            <Sun className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
-          ) : (
-            <Moon className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
-          )}
-        </button>
-      </div>
-      {/* Notifications */}
+      ) : (
+        <>
+          <div className="flex justify-start items-center gap-8 text-sm text-foregroundSec dark:text-foregroundSec-dark">
+            <button onClick={onMenuClick}>
+              <PanelLeft className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
+            </button>
+            <span className="text-lg font-semibold text-center text-foregroundSec dark:text-foregroundSec-dark hover:bg-border dark:hover:bg-border-dark px-4 py-2 rounded-2xl transition-all hover:translate-x-0.5 ease-linear">
+              {pathname}
+            </span>
+          </div>
+          <div className="flex items-center gap-8 w-85">
+            <div className="flex items-center bg-muted/20 dark:bg-muted/40 px-3 py-1.5 rounded-full w-full text-muted dark:text-muted-dark hover:bg-muted/30 dark:hover:bg-muted-dark/30 cursor-pointer">
+              <Search className="w-4 h-4 mr-2 transition-transform ease-in hover:-translate-y-[0.1rem]" />
+              <input
+                type="text"
+                placeholder="Search"
+                className="bg-transparent w-full outline-none text-sm placeholder-muted dark:placeholder-muted-dark text-foreground dark:text-foreground-dark cursor-pointer transition-transform ease-in hover:-translate-y-[0.1rem]"
+              />
+              <kbd className="ml-2 text-xs text-muted dark:text-muted-dark bg-muted/20 dark:bg-muted-dark/20 px-1.5 py-0.5 rounded">
+                /
+              </kbd>
+            </div>
+            <button>
+              <Bell className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
+            </button>
+            <button onClick={toggleDarkMode}>
+              {isDarkMode ? (
+                <Sun className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
+              ) : (
+                <Moon className="w-5 h-5 text-foregroundSec dark:text-foregroundSec-dark hover:text-primary transition-all cursor-pointer ease-in hover:-translate-y-[0.1rem]" />
+              )}
+            </button>
+          </div>
+        </>
+      )}
     </header>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,19 +4,33 @@ import { getToken } from "next-auth/jwt";
 
 export async function middleware(req: NextRequest) {
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const { pathname } = req.nextUrl;
 
-  const protectedRoutes = ["/produtos/api", "/estoque/api"];
-  const isProtected = protectedRoutes.some((path) =>
-    req.nextUrl.pathname.startsWith(path)
+  const protectedApiRoutes = ["/produtos/api", "/estoque/api"];
+  const isProtectedApi = protectedApiRoutes.some((path) =>
+    pathname.startsWith(path)
   );
 
-  if (isProtected && !token) {
+  if (isProtectedApi && !token) {
     return NextResponse.json({ message: "Não autorizado" }, { status: 401 });
+  }
+
+  const publicRoutes = ["/login", "/403"];
+  const isPublic = publicRoutes.some((path) => pathname.startsWith(path));
+
+  if (!token && !isPublic && !isProtectedApi) {
+    const url = req.nextUrl.clone();
+    url.pathname = "/403";
+    return NextResponse.redirect(url);
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/produtos/api/:path*", "/estoque/api/:path*"]
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+    "/produtos/api/:path*",
+    "/estoque/api/:path*",
+  ],
 };


### PR DESCRIPTION
## Summary
- hide sidebar on 403 page and show only the logo in the header
- adjust header to render minimal layout on the forbidden page
- protect all pages via middleware to redirect unauthenticated users to `/403`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706698e8848326b540da3f1707a0d4