### PR TITLE
Add client table and relationships

### DIFF
--- a/prisma/migrations/20250701030000_add_client_table_and_relations/migration.sql
+++ b/prisma/migrations/20250701030000_add_client_table_and_relations/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "Client" (
+    "idClient" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "corporateName" TEXT,
+    "phone" TEXT,
+    "state" TEXT,
+    "country" TEXT,
+    "city" TEXT,
+    "address" TEXT,
+    "cpfCnpj" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL,
+    CONSTRAINT "Client_pkey" PRIMARY KEY ("idClient")
+);
+
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN     "clientId" INTEGER NOT NULL;
+ALTER TABLE "ProductDetail" ADD COLUMN     "clientId" INTEGER NOT NULL;
+ALTER TABLE "Supplier" ADD COLUMN     "clientId" INTEGER NOT NULL;
+ALTER TABLE "SupplierInfo" ADD COLUMN     "clientId" INTEGER NOT NULL;
+ALTER TABLE "StockMovement" ADD COLUMN     "clientId" INTEGER NOT NULL;
+ALTER TABLE "User" ADD COLUMN     "clientId" INTEGER NOT NULL;
+ALTER TABLE "Category" ADD COLUMN     "clientId" INTEGER NOT NULL;
+ALTER TABLE "Role" ADD COLUMN     "clientId" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "ProductDetail" ADD CONSTRAINT "ProductDetail_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Supplier" ADD CONSTRAINT "Supplier_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "SupplierInfo" ADD CONSTRAINT "SupplierInfo_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "StockMovement" ADD CONSTRAINT "StockMovement_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "User" ADD CONSTRAINT "User_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Category" ADD CONSTRAINT "Category_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Role" ADD CONSTRAINT "Role_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("idClient") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,28 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Client {
+  idClient      Int     @id @default(autoincrement())
+  name          String
+  corporateName String?
+  phone         String?
+  state         String?
+  country       String?
+  city          String?
+  address       String?
+  cpfCnpj       String
+  isActive      Boolean
+
+  Product       Product[]
+  ProductDetail ProductDetail[]
+  Supplier      Supplier[]
+  SupplierInfo  SupplierInfo[]
+  StockMovement StockMovement[]
+  User          User[]
+  Category      Category[]
+  Role          Role[]
+}
+
 model Product {
   id           Int      @id @default(autoincrement())
   name         String
@@ -18,6 +40,7 @@ model Product {
   quantity     Int
   supplierId   Int?
   categoryId   Int?
+  clientId     Int
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
@@ -25,11 +48,13 @@ model Product {
   Supplier      Supplier?       @relation(fields: [supplierId], references: [id])
   StockMovement StockMovement[]
   ProductDetail ProductDetail?
+  Client        Client          @relation(fields: [clientId], references: [idClient])
 }
 
 model ProductDetail {
   id             Int     @id @default(autoincrement())
   productId      Int     @unique
+  clientId       Int
   brand          String?
   model          String?
   dimensions     String?
@@ -39,6 +64,7 @@ model ProductDetail {
   additionalInfo String?
 
   Product Product @relation(fields: [productId], references: [id])
+  Client  Client  @relation(fields: [clientId], references: [idClient])
 }
 
 model Supplier {
@@ -58,25 +84,31 @@ model Supplier {
   secondaryPhone   String?
   secondaryEmail   String?
   website          String?
+  clientId         Int
   products         Product[]
   supplierInfo     SupplierInfo?
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt
+
+  Client           Client        @relation(fields: [clientId], references: [idClient])
 }
 
 model SupplierInfo {
   id             Int     @id @default(autoincrement())
   supplierId     Int     @unique
+  clientId       Int
   paymentTerms   String?
   paymentMethods String?
   freightTerms   String?
 
   Supplier Supplier @relation(fields: [supplierId], references: [id])
+  Client   Client   @relation(fields: [clientId], references: [idClient])
 }
 
 model StockMovement {
   id        Int      @id @default(autoincrement())
   productId Int
+  clientId  Int
   type      String // "in" para entrada, "out" para saída
   quantity  Int
   date      DateTime @default(now())
@@ -84,6 +116,7 @@ model StockMovement {
 
   User    User    @relation(fields: [userId], references: [id])
   Product Product @relation(fields: [productId], references: [id])
+  Client  Client  @relation(fields: [clientId], references: [idClient])
 }
 
 model User {
@@ -93,22 +126,29 @@ model User {
   password  String
   image     String?
   role      Int      @default(0)
+  clientId  Int
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   Role          Role            @relation(fields: [role], references: [id])
   StockMovement StockMovement[]
+  Client        Client          @relation(fields: [clientId], references: [idClient])
 }
 
 model Category {
   id       Int       @id @default(autoincrement())
   title    String
+  clientId Int
   products Product[]
+
+  Client   Client @relation(fields: [clientId], references: [idClient])
 }
 
 model Role {
   id    Int    @id @default(autoincrement())
   title String
+  clientId Int
 
-  User User[]
+  User   User[]
+  Client Client @relation(fields: [clientId], references: [idClient])
 }

--- a/src/types/Category.ts
+++ b/src/types/Category.ts
@@ -1,4 +1,5 @@
 export type Category = {
   id: number;
   title: string;
+  clientId: number;
 };

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -1,0 +1,12 @@
+export type Client = {
+  idClient: number;
+  name: string;
+  corporateName?: string | null;
+  phone?: string | null;
+  state?: string | null;
+  country?: string | null;
+  city?: string | null;
+  address?: string | null;
+  cpfCnpj: string;
+  isActive: boolean;
+};

--- a/src/types/Product.ts
+++ b/src/types/Product.ts
@@ -9,6 +9,7 @@ export type Product = {
   quantity: number;
   categoryId?: number | null;
   supplierId?: number | null;
+  clientId: number;
   createdAt?: string;
   updatedAt?: string;
   Supplier?: { name: string };

--- a/src/types/StockMovement.ts
+++ b/src/types/StockMovement.ts
@@ -1,6 +1,7 @@
 export type StockMovement = {
   id?: number;
   productId: number;
+  clientId: number;
   type: "in" | "out";
   quantity: number;
   date?: string;

--- a/src/types/Supplier.ts
+++ b/src/types/Supplier.ts
@@ -21,6 +21,7 @@ export type Supplier = {
   secondaryPhone?: string | null;
   secondaryEmail?: string | null;
   website?: string | null;
+  clientId: number;
   supplierInfo?: SupplierInfo | null;
   products?: import("./Product").Product[];
   createdAt?: string;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -6,6 +6,7 @@ export type User = {
   name: string;
   email: string;
   password: string;
+  clientId: number;
   image?: string | null;
   role: number;
   createdAt: Date;


### PR DESCRIPTION
## Summary
- add `Client` table to Prisma schema
- connect all existing models with a `clientId` foreign key
- create migration for the new table and relations
- add TypeScript definitions for Client and updated types

## Testing
- `npx prisma format` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff95e78908326abde91e72cd6be15