### PR TITLE
Fix user creation API and email handling

### DIFF
--- a/src/app/userCreation/page.tsx
+++ b/src/app/userCreation/page.tsx
@@ -29,12 +29,17 @@ export default function CreateUserPage() {
     setLoading(true);
     console.log("Dados do formulário:", values);
     try {
+      const payload = {
+        ...values,
+        role: Number(values.role),
+        clientId: Number(values.clientId),
+      };
       const response = await fetch("/api/user/create", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(values),
+        body: JSON.stringify(payload),
       });
 
       const data = await response.json();
@@ -43,7 +48,13 @@ export default function CreateUserPage() {
         throw new Error(data.message || "Erro ao criar usuário.");
       }
 
-      toast.success("Usuário criado com sucesso!");
+      if (data.emailSent === false) {
+        toast.warning(
+          "Usuário criado, mas houve falha ao enviar o e-mail de boas-vindas."
+        );
+      } else {
+        toast.success("Usuário criado com sucesso!");
+      }
     } catch (err: any) {
       toast.error(err.message || "Erro ao criar usuário.");
     } finally {


### PR DESCRIPTION
## Summary
- improve user creation API
  - ensure a role entry exists before creating the user
  - allow user creation even if email sending fails and return `emailSent` flag
- show warnings on user creation page when email couldn't be sent
- coerce form data to numbers before submitting

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6884e18ab1cc83268cce619f53b35ada