### PR TITLE
Atualizar quantidade de produto ao registrar movimento de estoque

### DIFF
--- a/src/app/estoque/api/create/route.ts
+++ b/src/app/estoque/api/create/route.ts
@@ -21,9 +21,12 @@ export async function POST(request: Request) {
     return NextResponse.json(movement, { status: 201 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json(
-      { message: "Erro ao criar movimentação." },
-      { status: 500 }
-    );
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Erro ao criar movimentação.";
+    const status = error instanceof Error ? 400 : 500;
+
+    return NextResponse.json({ message }, { status });
   }
 }


### PR DESCRIPTION
## Summary
- Atualiza a quantidade de produtos ao registrar movimentações de estoque, com validação para evitar saldo negativo.
- Retorna mensagens de erro mais claras na API de criação de movimentações.

## Testing
- ⚠️ `npm run lint` (falha: diversos erros de lint existentes no projeto)
- ✅ `npx eslint src/app/services/stockMovementService.ts src/app/estoque/api/create/route.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acfc928d6083269d962d49e7ce56f8